### PR TITLE
Jenkins - Fix for EC2 Fleet plugin

### DIFF
--- a/jenkins/jenkins2-ha-agents.yaml
+++ b/jenkins/jenkins2-ha-agents.yaml
@@ -617,11 +617,23 @@ Resources:
             Action:
             - 'ec2:CreateTags'
             - 'ec2:DescribeInstances'
+            - 'ec2:DescribeInstanceStatus'
+            - 'ec2:DescribeRegions'
             - 'ec2:DescribeSpotFleetInstances'
             - 'ec2:DescribeSpotFleetRequests'
             - 'ec2:ModifySpotFleetRequest'
             - 'ec2:TerminateInstances'
             - 'ec2:UpdateAutoScalingGroup'
+            Resource: '*'
+      - PolicyName: iam
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - 'iam:ListInstanceProfiles'
+            - 'iam:ListRoles'
+            - 'iam:PassRole'
             Resource: '*'
   MasterIAMPolicySSHAccess:
     Type: 'AWS::IAM::Policy'

--- a/jenkins/jenkins2-ha-agents.yaml
+++ b/jenkins/jenkins2-ha-agents.yaml
@@ -621,6 +621,7 @@ Resources:
             - 'ec2:DescribeSpotFleetRequests'
             - 'ec2:ModifySpotFleetRequest'
             - 'ec2:TerminateInstances'
+            - 'ec2:UpdateAutoScalingGroup'
             Resource: '*'
   MasterIAMPolicySSHAccess:
     Type: 'AWS::IAM::Policy'

--- a/jenkins/jenkins2-ha-agents.yaml
+++ b/jenkins/jenkins2-ha-agents.yaml
@@ -193,7 +193,7 @@ Parameters:
     Default: 14
     AllowedValues: [1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653]
   AgentAMI:
-    Description: 'Specifies the number of days you want to retain log events in the specified log group.'
+    Description: 'Specifies the AMI of the agent.'
     Type: AWS::EC2::Image::Id
     Default: 'ami-06ab714a858dd8b2b'
   SubDomainNameWithDot:

--- a/jenkins/jenkins2-ha-agents.yaml
+++ b/jenkins/jenkins2-ha-agents.yaml
@@ -60,6 +60,7 @@ Metadata:
       - AgentMinSize
       - AgentMaxBuildWaitTimeInSeconds
       - AgentLogsRetentionInDays
+      - AgentAMI
     - Label:
         default: 'Security'
       Parameters:
@@ -191,6 +192,10 @@ Parameters:
     Type: Number
     Default: 14
     AllowedValues: [1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653]
+  AgentAMI:
+    Description: 'Specifies the number of days you want to retain log events in the specified log group.'
+    Type: AWS::EC2::Image::Id
+    Default: 'ami-06ab714a858dd8b2b'
   SubDomainNameWithDot:
     Description: 'Name that is used to create the DNS entry with trailing dot, e.g. §{SubDomainNameWithDot}§{HostedZoneName}. Leave blank for naked (or apex and bare) domain. Requires ParentZoneStack parameter!'
     Type: String
@@ -2005,7 +2010,7 @@ Resources:
                 - '/opt/agent-healthcheck/daemon.rb'
                 - '/opt/agent-healthcheck/server.rb'
     Properties:
-      ImageId: !FindInMap [RegionMap, !Ref 'AWS::Region', AMI]
+      ImageId: !Ref AgentAMI
       IamInstanceProfile: !Ref AgentIP
       InstanceType: !Ref AgentInstanceType
       SecurityGroups:

--- a/jenkins/jenkins2-ha-agents.yaml
+++ b/jenkins/jenkins2-ha-agents.yaml
@@ -553,6 +553,7 @@ Resources:
               - 'ssmmessages:*' # SSM Agent by https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-setting-up-messageAPIs.html
               - 'ssm:UpdateInstanceInformation' # SSM agent by https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-setting-up-messageAPIs.html
               - 'ec2messages:*' # SSM Session Manager by https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-setting-up-messageAPIs.html
+              - 'ssm:ListInstanceAssociations'
               Resource: '*'
         - !Ref 'AWS::NoValue'
       - PolicyName: cloudwatch
@@ -569,7 +570,10 @@ Resources:
           Statement:
           - Sid: write
             Effect: Allow
-            Action: 'autoscaling:CompleteLifecycleAction'
+            Action:
+            - 'autoscaling:CompleteLifecycleAction'
+            - 'autoscaling:DescribeAutoScalingGroups'
+            - 'autoscaling:UpdateAutoScalingGroup'
             Resource: '*'
       - PolicyName: sqs
         PolicyDocument:
@@ -599,6 +603,19 @@ Resources:
           Statement:
           - Effect: Allow
             Action: 'sts:AssumeRole'
+            Resource: '*'
+      - PolicyName: ec2
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - 'ec2:CreateTags'
+            - 'ec2:DescribeInstances'
+            - 'ec2:DescribeSpotFleetInstances'
+            - 'ec2:DescribeSpotFleetRequests'
+            - 'ec2:ModifySpotFleetRequest'
+            - 'ec2:TerminateInstances'
             Resource: '*'
   MasterIAMPolicySSHAccess:
     Type: 'AWS::IAM::Policy'
@@ -1693,7 +1710,7 @@ Resources:
                   SaveUserName=${SaveUserName//"@"/".at."}
                   if [ "${#SaveUserName}" -le "32" ]; then
                     if ! id -u "$SaveUserName" >/dev/null 2>&1; then
-                      #sudo will read each file in /etc/sudoers.d, skipping file names that end in ‘~’ or contain a ‘.’ character to avoid causing problems with package manager or editor temporary/backup files.
+                      #sudo will read each file in /etc/sudoers.d, skipping file names that end in ?~? or contain a ?.? character to avoid causing problems with package manager or editor temporary/backup files.
                       SaveUserFileName=$(echo "$SaveUserName" | tr "." " ")
                       /usr/sbin/useradd "$SaveUserName"
                       echo "$SaveUserName ALL=(ALL) NOPASSWD:ALL" > "/etc/sudoers.d/$SaveUserFileName"


### PR DESCRIPTION
This was branched off `jenkins/add-ingress-cidr-allow` to fix permission issues for the EC2 Fleet Plugin for Jenkins.
It also allows us to specify the agent AMI as a parameter.